### PR TITLE
DOI is not a valid/resolvable DOI

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ A full reconciled dataset of all four databases that includes non-mammal hosts, 
 
 To use these data, please cite the DOI for the repository provided by Zenodo, and a citation of the preprint:
 
-R Gibb, GF Albery, DJ Becker, L Brierley, R Connor, TA Dallas, EA Eskew, MJ Farrell, AL Rasmussen, SJ Ryan, AR Sweeny, CJ Carlson, T Poisot. Data proliferation, reconciliation, and synthesis in viral ecology. First posted January 16, 2021. bioRxiv DOI: 10.1101/2021.01.14.426572v1.
+R Gibb, GF Albery, DJ Becker, L Brierley, R Connor, TA Dallas, EA Eskew, MJ Farrell, AL Rasmussen, SJ Ryan, AR Sweeny, CJ Carlson, T Poisot. Data proliferation, reconciliation, and synthesis in viral ecology. First posted January 16, 2021. bioRxiv DOI: [10.1101/2021.01.14.426572](https://doi.org/10.1101/2021.01.14.426572).
 
 ### Contact information
 


### PR DESCRIPTION
The DOI to the Gibb et al preprint is not a known or resolvable DOI because of the `v1` appended to the end of the DOI. This PR corrects the DOI so that is resolves to the biorxiv preprint. Additionally, the DOI has been turned into a hyperlink to facilitate accessing the preprint.